### PR TITLE
use -thumbnail instead of -resize imagemagick option

### DIFF
--- a/AppImage-thumbnailer
+++ b/AppImage-thumbnailer
@@ -17,6 +17,6 @@ while file -bi "$thumb" | grep 'inode/symlink' &> /dev/null; do
   thumb="$(file "$thumb" | rev | cut -d " " -f 1 | rev)"
   thumb="$("$inFile" --appimage-extract "$thumb")"
 done
-convert  -background none -resize "$size" "$thumb" "$tmpThumb" 
+convert  -background none -thumbnail "$size" "$thumb" "$tmpThumb" 
 mv "$tmpThumb" "$outFile"
 rm -r $tmpDir


### PR DESCRIPTION
convert's option `-thumbnail` is specially designed to handle thumbnailers (see [doc](https://legacy.imagemagick.org/script/command-line-options.php#thumbnail)).

In particular it has 2 features that makes it probably a better pick : 

- it strips all original metadata (size :+1: )
- (undocumented) it registers `Thumb::MTime` and `Thumb::URI`along with other recommended keys from the [freedesktop specification](https://specifications.freedesktop.org/thumbnail-spec/thumbnail-spec-latest.html#CREATION).

Anyways, I took your script and I needed this change to make it work, thought I'd let you know!