### PR TITLE
fix : not working for AppImages with recent runtime

### DIFF
--- a/AppImage-thumbnailer
+++ b/AppImage-thumbnailer
@@ -12,11 +12,15 @@ if ! mkdir -p $tmpDir; then
 fi
 cd $tmpDir
 
-thumb="$("$inFile" --appimage-extract '.DirIcon')"
+"$inFile" --appimage-extract '.DirIcon'
+thumb='squashfs-root/.DirIcon'
+
 while file -bi "$thumb" | grep 'inode/symlink' &> /dev/null; do
   thumb="$(file "$thumb" | rev | cut -d " " -f 1 | rev)"
-  thumb="$("$inFile" --appimage-extract "$thumb")"
+  "$inFile" --appimage-extract "$thumb"
+  thumb="squashfs-root/$thumb"
 done
+
 convert  -background none -thumbnail "$size" "$thumb" "$tmpThumb" 
 mv "$tmpThumb" "$outFile"
 rm -r $tmpDir


### PR DESCRIPTION
AppImages with recents runtimes does not output filename in commandline. So this does not work.
We have to assume that output filename will be squashfs-root/.DirIcon .